### PR TITLE
Remove unused findCurrentStep helper

### DIFF
--- a/src/domain/session.ts
+++ b/src/domain/session.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { AskStep, Lesson } from './lesson.js';
+import type { Lesson } from './lesson.js';
 
 export const interactionLogSchema = z.object({
   timestamp: z.string().datetime(),
@@ -40,16 +40,4 @@ export function createInitialSession(lesson: Lesson, sessionId: string): LessonS
     lessonCompleted: false,
     history: []
   };
-}
-
-export function findCurrentStep(session: LessonSession): AskStep | null {
-  const moment = session.lesson.moments[session.currentMomentIndex];
-  if (!moment) {
-    return null;
-  }
-  const step = moment.steps[session.currentStepIndex];
-  if (!step || step.type !== 'ASK') {
-    return null;
-  }
-  return step;
 }


### PR DESCRIPTION
## Summary
- remove the unused `findCurrentStep` helper from the session domain model
- drop the redundant `AskStep` import now that the helper is gone

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d8acfc1c94832c8c7ac2ef6b376986