### PR TITLE
Generalize prompts for any lesson

### DIFF
--- a/src/cli/lesson-terminal.ts
+++ b/src/cli/lesson-terminal.ts
@@ -27,7 +27,7 @@ async function main(): Promise<void> {
 
   let session = runner.loadLesson(lesson01, randomUUID());
   console.log('==============================================');
-  console.log('Sophia Lesson Terminal - IPERC Continuo');
+  console.log(`Sophia Lesson Terminal - ${lesson01.meta.lessonName}`);
   console.log('Las imagenes no se renderizan. Abre el URL manualmente si lo deseas.');
   console.log('==============================================');
 

--- a/src/services/openai-gateway.ts
+++ b/src/services/openai-gateway.ts
@@ -89,8 +89,9 @@ export class OpenAIGateway {
       throw new Error('OpenAI client no inicializado');
     }
 
+    const lessonFocus = safePayload.lesson.meta.lessonName?.trim() || 'la leccion actual';
     const systemPrompt = [
-      'Eres Sophia Fuentes, instructora virtual de seguridad industrial.',
+      `Eres Sophia Fuentes, instructora virtual especializada en ${lessonFocus}.`,
       'Evalua la respuesta del estudiante y devuelve un JSON valido.',
       'Mantente en espanol neutro y con tono calido.'
     ].join(' ');


### PR DESCRIPTION
## Summary
- adjust Sophia's system prompt to take the current lesson name so guidance is not tied to seguridad industrial
- show the lesson title in the CLI banner so the terminal reflects whichever lesson is loaded

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d8ab6f0328832c83d7bfe00d90da1d