### PR TITLE
Clarify response contract and history metadata

### DIFF
--- a/dist/agents/educational-roles.js
+++ b/dist/agents/educational-roles.js
@@ -1,0 +1,167 @@
+export class EducationalRoles {
+    static getInstructions(role, context) {
+        const baseHeader = 'Rol asignado:';
+        let intro;
+        switch (role) {
+            case 'ORCHESTRATOR':
+                intro = 'Facilita la experiencia completa, conecta objetivos y marca el ritmo.';
+                break;
+            case 'EVALUATOR':
+                intro = 'Evalua la respuesta del estudiante contra el objetivo del paso y decide si avanza.';
+                break;
+            case 'CLARIFICATION':
+                intro = 'Aclara dudas, descompone conceptos y brinda ejemplos sencillos.';
+                break;
+            case 'CONTENT_GENERATOR':
+                intro = 'Aporta contenido adicional, casos y analogias que fortalezcan el aprendizaje.';
+                break;
+            case 'META_HANDLER':
+                intro = 'Motiva, refuerza metacognicion y ayuda a conectar con objetivos personales.';
+                break;
+            case 'HINT_COACH':
+                intro = 'Reformula la pregunta, entrega pistas concretas y explicita los elementos que debe cubrir la siguiente respuesta sin revelar la solucion.';
+                break;
+            case 'QUESTIONER':
+                intro = 'Formula repreguntas directas, propone caminos de respuesta y mantiene al estudiante enfocado en el objetivo.';
+                break;
+            case 'FEEDBACKER':
+                intro = 'Sintetiza avances, recalca pendientes y cierra con una pauta concreta para el siguiente movimiento.';
+                break;
+            default:
+                intro = 'Acompana el progreso del estudiante manteniendo coherencia con la leccion.';
+                break;
+        }
+        const reminderPieces = [
+            'Mantener coherencia con la personalidad base de Sophia.',
+            'Referenciar el objetivo pedagogico al justificar acciones.',
+            'No inventar datos factuales; apalancar la informacion provista en la leccion.',
+            'Recuerda que el estudiante puede formular preguntas sobre el tema y responde a esas dudas con detalle.'
+        ];
+        if (role === 'HINT_COACH') {
+            reminderPieces.push('En modo pista evita elogios y centra el mensaje en cerrar las brechas detectadas.');
+        }
+        const reminders = reminderPieces.join(' ');
+        const firstMomentReminder = context.currentMoment.code === 'M1'
+            ? 'Si se trata del primer momento, presenta la leccion, objetivos y puntos clave antes de continuar.'
+            : 'Si no es el primer momento, evita presentaciones extensas y continua el flujo natural.';
+        const sections = [baseHeader, intro, reminders, firstMomentReminder];
+        if (role === 'QUESTIONER') {
+            sections.push('Modo repregunta: formula una sola pregunta clara y concreta, vinculada con el objetivo del paso.');
+            sections.push('Incluye hasta dos posibles enfoques en formato de lista si es util y agrega hasta dos pistas breves sin revelar la respuesta completa.');
+            sections.push('Mantén tus pistas enfocadas en los elementos que aun falta abordar.');
+        }
+        if (role === 'FEEDBACKER') {
+            sections.push('Modo feedback: sintetiza logros y pendientes en maximo tres frases. Cierra con una accion concreta.');
+        }
+        if (role === 'EVALUATOR') {
+            sections.push('Modo evaluador: no formules preguntas directas ni utilices signos de interrogacion.');
+            sections.push('Describe brechas y orienta con indicaciones declarativas ("Amplia con ejemplos concretos", "Relaciona con tu experiencia").');
+        }
+        const messageTypeDirective = role === 'HINT_COACH'
+            ? 'PISTA'
+            : role === 'QUESTIONER'
+                ? 'PREGUNTA'
+                : role === 'FEEDBACKER'
+                    ? 'FEEDBACK'
+                    : 'FEEDBACK';
+        sections.push(`Debes devolver en el JSON la clave "messageType" con el valor "${messageTypeDirective}".`);
+        if (role === 'HINT_COACH') {
+            const hintGuidelines = [
+                'Modo pistas: reformula o repite la pregunta destacando que el estudiante debe intentarlo de nuevo.',
+                context.question
+                    ? `Pregunta original a reiterar: "${context.question}".`
+                    : 'Retoma la pregunta original con tus palabras, sin cambiar su sentido.',
+                `Ofrece hasta tres pistas claras conectadas con el objetivo: ${context.objective}.`,
+                'Enumera los elementos minimos que esperas en la siguiente respuesta (usa vinetas o numeracion).',
+                'No des la respuesta completa; orienta el razonamiento y cierra con una invitacion directa a responder.'
+            ];
+            if (context.answerType === 'list') {
+                hintGuidelines.push('Indica cuantos elementos aproximadamente esperas en la lista y menciona uno como pista sin completar todos.');
+            }
+            else if (context.answerType === 'procedure') {
+                hintGuidelines.push('Sugiere el primer paso correcto y pide que complete el resto siguiendo una secuencia logica.');
+            }
+            else if (context.answerType === 'definition') {
+                hintGuidelines.push('Anticipa dos atributos clave que debe contener la definicion sin redactarla por completo.');
+            }
+            sections.push(...hintGuidelines);
+        }
+        return sections.join('\n');
+    }
+    static decideRoleFromInput(userInput, context) {
+        const lower = userInput.trim().toLowerCase();
+        const normalized = lower.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+        const hasQuestionMark = userInput.includes('?') || userInput.includes(String.fromCharCode(0x00bf));
+        const directedQuestion = hasQuestionMark && /\b(puedes|podrias|podras|ayuda|ayudame|ayudeme|explica|explicame|aclara|aclarame|respondeme|responde)\b/.test(normalized);
+        const clarificationPhrases = [
+            'tengo una duda',
+            'tengo duda',
+            'tengo una pregunta',
+            'no entiendo',
+            'no comprendo',
+            'puedes responder',
+            'me puedes responder',
+            'puedes ayudar',
+            'me puedes ayudar',
+            'necesito ayuda',
+            'ayudame',
+            'puedes explicar',
+            'me puedes explicar',
+            'podrias explicar',
+            'podrias responder',
+            'podrias ayudarme',
+            'aclarame',
+            'aclarar',
+            'aclaracion',
+            'explica',
+            'explicame',
+            'identificacion temprana',
+            'identificacion tempran',
+            'deteccion temprana',
+            'deteccion tempran',
+            'a que te refieres',
+            'que te refieres',
+            'a que se refiere',
+            'que quieres decir',
+            'que significa'
+        ];
+        const clarificationPatterns = [
+            /\ba que te refieres\b/,
+            /\bque te refieres\b/,
+            /\ba que se refiere\b/,
+            /\bque quieres decir\b/,
+            /\bque significa\b/,
+            /identificacion tempran/,
+            /deteccion tempran/,
+            /explica la identificacion/,
+            /explicame la identificacion/,
+            /explica la deteccion/,
+            /explicame la deteccion/
+        ];
+        const expressesClarification = clarificationPhrases.some(phrase => normalized.includes(phrase)) ||
+            clarificationPatterns.some(pattern => pattern.test(normalized));
+        if (expressesClarification || directedQuestion) {
+            return { role: 'CLARIFICATION', intent: 'CLARIFICATION_CONCEPTUAL' };
+        }
+        if (context.currentMoment.code === 'M1' && context.historyLength === 0) {
+            return { role: 'ORCHESTRATOR', intent: 'INTRODUCTION' };
+        }
+        if (hasQuestionMark) {
+            return { role: 'CLARIFICATION', intent: 'CLARIFICATION_CONCEPTUAL' };
+        }
+        const hintKeywords = ['no se', 'no lo se', 'dame una pista', 'necesito una pista', 'ayuda'];
+        if (hintKeywords.some(keyword => normalized.includes(keyword))) {
+            return { role: 'HINT_COACH', intent: 'HINT_REINFORCEMENT' };
+        }
+        if (normalized.includes('dame un ejemplo') || normalized.includes('necesito mas')) {
+            return { role: 'CONTENT_GENERATOR', intent: 'CONTENT_EXTENSION' };
+        }
+        if (normalized.includes('me cuesta') || normalized.includes('estoy frustrado') || normalized.includes('motiv')) {
+            return { role: 'META_HANDLER', intent: 'META_REFLECTION' };
+        }
+        if (context.lastClassification === 'HINT') {
+            return { role: 'HINT_COACH', intent: 'HINT_REINFORCEMENT' };
+        }
+        return { role: 'EVALUATOR', intent: 'EVALUATION' };
+    }
+}

--- a/dist/agents/sophia-personality.js
+++ b/dist/agents/sophia-personality.js
@@ -1,0 +1,97 @@
+const momentIntentMap = {
+    M1: {
+        purpose: 'Dar la bienvenida y situar la leccion',
+        focus: 'Presentar el objetivo general y despertar curiosidad',
+        interaction: 'Introduccion y primera exploracion'
+    },
+    M2: {
+        purpose: 'Conectar con conocimientos previos',
+        focus: 'Relacionar el tema con experiencias reales del estudiante',
+        interaction: 'Preguntas sobre situaciones conocidas'
+    },
+    M3: {
+        purpose: 'Transmitir conocimiento estructurado',
+        focus: 'Explicar conceptos clave y metodologias',
+        interaction: 'Contenido teorico y preguntas de comprension'
+    },
+    M4: {
+        purpose: 'Aplicar lo aprendido',
+        focus: 'Resolver casos o escenarios practicos',
+        interaction: 'Analisis guiado paso a paso'
+    },
+    M5: {
+        purpose: 'Profundizar y justificar decisiones',
+        focus: 'Reflexionar sobre elecciones y criterios',
+        interaction: 'Argumentacion y discusion'
+    },
+    M6: {
+        purpose: 'Reflexionar y proyectar a la practica',
+        focus: 'Conectar aprendizajes con tareas cotidianas',
+        interaction: 'Metacognicion y plan de accion personal'
+    }
+};
+export class SophiaPersonality {
+    static buildBaseVoice() {
+        return [
+            'Eres Sophia Fuentes, una instructora virtual calida y empatica.',
+            'Normalmente empiezas resaltando logros concretos del estudiante, luego amplias la idea y cierras celebrando el avance, excepto si determinas que la clasificacion debe ser "HINT"; en ese caso evita elogios y se directa sobre lo que falta.',
+            'Hablas en espanol claro y natural, con energia positiva y cercana.'
+        ].join(' ');
+    }
+    static buildContext(context) {
+        const totalSteps = context.lesson.moments.reduce((acc, moment) => acc + moment.steps.length, 0);
+        const lines = [];
+        lines.push(`Leccion: ${context.lesson.meta.lessonName}`);
+        lines.push(`Momento actual: ${context.currentMoment.code} - ${context.currentMoment.title}`);
+        lines.push(`Paso en curso: ${context.stepCode}`);
+        lines.push(`Objetivo pedagogico: ${context.objective}`);
+        lines.push(`Intentos del estudiante en este paso: ${context.attempts}`);
+        lines.push(`Interacciones totales en la sesion: ${context.historyLength}`);
+        lines.push(`Total de pasos en la leccion: ${totalSteps}`);
+        if (context.question) {
+            lines.push(`Pregunta original del paso: ${context.question}`);
+        }
+        if (context.answerType) {
+            lines.push(`Tipo de respuesta esperado: ${context.answerType}`);
+        }
+        if (context.lastClassification) {
+            lines.push(`Ultima clasificacion recibida: ${context.lastClassification}`);
+        }
+        const intent = momentIntentMap[context.currentMoment.code];
+        if (intent) {
+            lines.push(`Proposito del momento: ${intent.purpose}`);
+            lines.push(`Enfoque principal: ${intent.focus}`);
+            lines.push(`Tipo de interaccion: ${intent.interaction}`);
+        }
+        if (context.hasImage && context.imageDescription) {
+            lines.push(`Descripcion de imagen disponible para apoyar la explicacion: ${context.imageDescription}`);
+        }
+        return lines.join('\n');
+    }
+    static buildToneGuidelines() {
+        return [
+            'Consejos de tono conversacional:',
+            '- Presenta el contenido como si hablaras cara a cara, usando expresiones como "Vamos a explorar..." o "Cuentame...".',
+            '- Invita a la reflexion con preguntas abiertas y cercanas.',
+            '- Si compartes definiciones o listas, introducelas con frases narrativas ("Primero revisemos...", "Ademas considera...").'
+        ].join('\n');
+    }
+    static buildInstructions(context) {
+        return [
+            this.buildBaseVoice(),
+            '',
+            'Tecnicas clave que debes aplicar en cada respuesta:',
+            '- Marco positivo: comienza destacando algo especifico que el estudiante hizo bien.',
+            '- Elogio preciso: cita elementos concretos o frases mencionadas por el estudiante.',
+            '- Warm/strict: mantiene estandares altos con calidez y guia motivadora.',
+            '- No opt out: si el estudiante duda, formula preguntas guia mas simples.',
+            '- Construye el impulso: conecta con logros previos para avanzar.',
+            '- Si la clasificacion es HINT: no felicites ni digas "buen intento"; explica con claridad que falta y orienta el siguiente paso.',
+            '',
+            this.buildToneGuidelines(),
+            '',
+            'Contexto pedagogico actual:',
+            this.buildContext(context)
+        ].join('\n');
+    }
+}

--- a/dist/domain/responses.js
+++ b/dist/domain/responses.js
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { riskMatrixResultSchema } from './risk-matrix.js';
 export const evaluationClassificationSchema = z.union([
     z.literal('ACCEPT'),
     z.literal('PARTIAL'),
@@ -37,5 +38,6 @@ export const sophiaResponseSchema = z.object({
             return undefined;
         }
         return value;
-    }, z.array(z.string()).optional())
+    }, z.array(z.string()).optional()),
+    riskMatrix: z.array(riskMatrixResultSchema).optional()
 });

--- a/dist/domain/risk-matrix.js
+++ b/dist/domain/risk-matrix.js
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+export const riskProbabilitySchema = z.union([
+    z.literal('rare'),
+    z.literal('unlikely'),
+    z.literal('possible'),
+    z.literal('likely'),
+    z.literal('almostCertain')
+]);
+export const riskSeveritySchema = z.union([
+    z.literal('minor'),
+    z.literal('moderate'),
+    z.literal('major'),
+    z.literal('critical')
+]);
+export const riskLevelSchema = z.union([
+    z.literal('low'),
+    z.literal('medium'),
+    z.literal('high'),
+    z.literal('extreme')
+]);
+export const riskMatrixResultSchema = z.object({
+    hazard: z.string().min(1),
+    description: z.string().optional(),
+    probability: riskProbabilitySchema,
+    severity: riskSeveritySchema,
+    riskLevel: riskLevelSchema,
+    justification: z.string().optional(),
+    existingControls: z.array(z.string()).optional(),
+    recommendedControls: z.array(z.string()).optional()
+});

--- a/dist/domain/session.js
+++ b/dist/domain/session.js
@@ -1,5 +1,7 @@
 import { z } from 'zod';
-export const interactionLogSchema = z.object({
+import { nextActionSchema } from './responses.js';
+import { riskMatrixResultSchema } from './risk-matrix.js';
+const interactionLogBaseSchema = z.object({
     timestamp: z.string().datetime(),
     stepCode: z.string(),
     question: z.string().optional(),
@@ -7,13 +9,38 @@ export const interactionLogSchema = z.object({
     agentResponse: z.string(),
     score: z.number().min(0).max(1).optional(),
     classification: z.string().optional(),
-    action: z.union([
-        z.literal('advance'),
-        z.literal('retry'),
-        z.literal('clarify'),
-        z.literal('complete')
-    ])
+    nextAction: nextActionSchema.optional(),
+    nextQuestion: z.string().optional(),
+    momentCompleted: z.boolean().optional(),
+    lessonCompleted: z.boolean().optional(),
+    needsAutomaticAdvance: z.boolean().optional(),
+    progressSummary: z.string().optional(),
+    weakAreas: z
+        .preprocess(value => {
+        if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (!trimmed) {
+                return [];
+            }
+            return trimmed.split(/[,\n]/).map(item => item.trim()).filter(Boolean);
+        }
+        if (Array.isArray(value)) {
+            return value;
+        }
+        if (value === undefined || value === null) {
+            return undefined;
+        }
+        return value;
+    }, z.array(z.string()).optional()),
+    riskMatrix: z.array(riskMatrixResultSchema).optional()
 });
+export const interactionLogSchema = z.preprocess(value => {
+    if (value && typeof value === 'object' && !Array.isArray(value) && 'action' in value && !value.nextAction) {
+        const { action, ...rest } = value;
+        return { ...rest, nextAction: action };
+    }
+    return value;
+}, interactionLogBaseSchema);
 export const lessonSessionSchema = z.object({
     sessionId: z.string(),
     lesson: z.custom(),

--- a/dist/services/openai-gateway.js
+++ b/dist/services/openai-gateway.js
@@ -2,6 +2,7 @@ import OpenAI from 'openai';
 import { z } from 'zod';
 import { lessonPlanSchema } from '../domain/lesson-plan.js';
 import { sophiaResponseSchema } from '../domain/responses.js';
+import { riskMatrixResultSchema } from '../domain/risk-matrix.js';
 import { messageTypeSchema } from '../domain/agent-messages.js';
 const conversationEntrySchema = z.object({
     role: z.union([z.literal('user'), z.literal('assistant')]),
@@ -9,8 +10,12 @@ const conversationEntrySchema = z.object({
     stepCode: z.string(),
     score: z.number().min(0).max(1).optional(),
     classification: z.string().optional(),
-    action: z.string().optional(),
-    timestamp: z.string().optional()
+    nextAction: z.string().optional(),
+    timestamp: z.string().optional(),
+    nextQuestion: z.string().optional(),
+    progressSummary: z.string().optional(),
+    weakAreas: z.array(z.string()).optional(),
+    riskMatrix: z.array(riskMatrixResultSchema).optional()
 });
 const evaluateStepRequestSchema = z.object({
     sessionId: z.string(),
@@ -79,8 +84,12 @@ export class OpenAIGateway {
             stepCode: entry.stepCode,
             score: entry.score,
             classification: entry.classification,
-            action: entry.action,
-            timestamp: entry.timestamp
+            nextAction: entry.nextAction,
+            timestamp: entry.timestamp,
+            nextQuestion: entry.nextQuestion,
+            progressSummary: entry.progressSummary,
+            weakAreas: entry.weakAreas,
+            riskMatrix: entry.riskMatrix
         }));
         const userPrompt = [
             'CONTEXTO_SESION_JSON',
@@ -103,8 +112,8 @@ export class OpenAIGateway {
             '- score: number entre 0 y 1.',
             '- nextAction: "advance"|"retry"|"clarify"|"complete".',
             '- nextQuestion (opcional).',
-            '- momentCompleted, lessonCompleted, needsAutomaticAdvance (opcional).',
-            '- progressSummary, weakAreas (opcional).',
+            '- momentCompleted, lessonCompleted, needsAutomaticAdvance (opcionales).',
+            '- progressSummary, weakAreas, riskMatrix (opcionales).',
             '',
             'No incluyas texto fuera del JSON.'
         ].join('\n');
@@ -154,8 +163,12 @@ export class OpenAIGateway {
                 stepCode: entry.stepCode,
                 score: entry.score,
                 classification: entry.classification,
-                action: entry.action,
-                timestamp: entry.timestamp
+                nextAction: entry.nextAction,
+                timestamp: entry.timestamp,
+                nextQuestion: entry.nextQuestion,
+                progressSummary: entry.progressSummary,
+                weakAreas: entry.weakAreas,
+                riskMatrix: entry.riskMatrix
             }))
         };
         const userPrompt = [

--- a/dist/services/sophia-multiagent-service.js
+++ b/dist/services/sophia-multiagent-service.js
@@ -34,12 +34,20 @@ export class SophiaMultiAgentService {
             question: step.question,
             answerType: step.answerType,
             lastClassification: snapshot.lastClassification,
-            lastAction: snapshot.lastAction
+            lastAction: snapshot.lastNextAction
         };
         const baseInstructions = SophiaPersonality.buildInstructions(personalityContext);
         const roleDecision = EducationalRoles.decideRoleFromInput(userInput, personalityContext);
         const roleInstructions = EducationalRoles.getInstructions(roleDecision.role, personalityContext);
         const evaluationGuidelines = buildEvaluationGuidelines(step.objective, snapshot.attempts);
+        /**
+         * Formato esperado por el evaluador automatico.
+         * Campos requeridos: chat, classification, score, nextAction.
+         * Campos opcionales: nextQuestion, momentCompleted, lessonCompleted, needsAutomaticAdvance,
+         * progressSummary, weakAreas, riskMatrix.
+         * El historial enviado al modelo utiliza InteractionLog (ver src/domain/session.ts) y mantiene los
+         * nombres exactos: classification, nextAction, history[].
+         */
         const finalInstructions = [
             baseInstructions,
             '',
@@ -53,7 +61,8 @@ export class SophiaMultiAgentService {
             '',
             'FORMATO_DE_RESPUESTA',
             'Entrega JSON valido con las claves requeridas: chat, classification, score, nextAction.',
-            'Incluye nextQuestion si planteas la siguiente pregunta y marca momentCompleted/lessonCompleted cuando aplique.'
+            'Campos opcionales segun aplique: nextQuestion, momentCompleted, lessonCompleted, needsAutomaticAdvance, progressSummary, weakAreas, riskMatrix.',
+            'Asegurate de que history siga el formato de InteractionLog y registra riskMatrix solo cuando proveas un RiskMatrixResult.'
         ].join('\n');
         const historyForModel = this.buildHistoryForModel(safeSession.history);
         const response = await this.gateway.evaluateStep({
@@ -91,7 +100,7 @@ export class SophiaMultiAgentService {
             attempts: historyForStep.length + 1,
             historyLength: session.history.length,
             lastClassification: lastEntry?.classification,
-            lastAction: lastEntry?.action
+            lastNextAction: lastEntry?.nextAction
         };
     }
     buildHistoryForModel(history) {
@@ -106,8 +115,11 @@ export class SophiaMultiAgentService {
                 stepCode: entry.stepCode,
                 score: entry.score,
                 classification: entry.classification,
-                action: entry.action,
-                timestamp: entry.timestamp
+                nextAction: entry.nextAction,
+                timestamp: entry.timestamp,
+                progressSummary: entry.progressSummary,
+                weakAreas: entry.weakAreas,
+                riskMatrix: entry.riskMatrix
             });
             if (entry.agentResponse) {
                 items.push({
@@ -116,8 +128,12 @@ export class SophiaMultiAgentService {
                     stepCode: entry.stepCode,
                     score: entry.score,
                     classification: entry.classification,
-                    action: entry.action,
-                    timestamp: entry.timestamp
+                    nextAction: entry.nextAction,
+                    timestamp: entry.timestamp,
+                    nextQuestion: entry.nextQuestion,
+                    progressSummary: entry.progressSummary,
+                    weakAreas: entry.weakAreas,
+                    riskMatrix: entry.riskMatrix
                 });
             }
         }
@@ -262,7 +278,14 @@ function applyResponseToSession(session, response, moment, step, userInput) {
         agentResponse: response.chat,
         score: response.score,
         classification: response.classification,
-        action: response.nextAction
+        nextAction: response.nextAction,
+        nextQuestion: response.nextQuestion,
+        momentCompleted: response.momentCompleted,
+        lessonCompleted: response.lessonCompleted,
+        needsAutomaticAdvance: response.needsAutomaticAdvance,
+        progressSummary: response.progressSummary,
+        weakAreas: response.weakAreas,
+        riskMatrix: response.riskMatrix
     };
     const history = [...session.history, interaction];
     let currentMomentIndex = session.currentMomentIndex;

--- a/src/domain/responses.ts
+++ b/src/domain/responses.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { riskMatrixResultSchema } from './risk-matrix.js';
 
 export const evaluationClassificationSchema = z.union([
   z.literal('ACCEPT'),
@@ -40,7 +41,8 @@ export const sophiaResponseSchema = z.object({
         return undefined;
       }
       return value;
-    }, z.array(z.string()).optional())
+    }, z.array(z.string()).optional()),
+  riskMatrix: z.array(riskMatrixResultSchema).optional()
 });
 
 export type SophiaResponse = z.infer<typeof sophiaResponseSchema>;

--- a/src/domain/risk-matrix.ts
+++ b/src/domain/risk-matrix.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+
+export const riskProbabilitySchema = z.union([
+  z.literal('rare'),
+  z.literal('unlikely'),
+  z.literal('possible'),
+  z.literal('likely'),
+  z.literal('almostCertain')
+]);
+
+export const riskSeveritySchema = z.union([
+  z.literal('minor'),
+  z.literal('moderate'),
+  z.literal('major'),
+  z.literal('critical')
+]);
+
+export const riskLevelSchema = z.union([
+  z.literal('low'),
+  z.literal('medium'),
+  z.literal('high'),
+  z.literal('extreme')
+]);
+
+export const riskMatrixResultSchema = z.object({
+  hazard: z.string().min(1),
+  description: z.string().optional(),
+  probability: riskProbabilitySchema,
+  severity: riskSeveritySchema,
+  riskLevel: riskLevelSchema,
+  justification: z.string().optional(),
+  existingControls: z.array(z.string()).optional(),
+  recommendedControls: z.array(z.string()).optional()
+});
+
+export type RiskMatrixResult = z.infer<typeof riskMatrixResultSchema>;

--- a/src/domain/session.ts
+++ b/src/domain/session.ts
@@ -1,7 +1,9 @@
 import { z } from 'zod';
 import type { AskStep, Lesson } from './lesson.js';
+import { nextActionSchema } from './responses.js';
+import { riskMatrixResultSchema } from './risk-matrix.js';
 
-export const interactionLogSchema = z.object({
+const interactionLogBaseSchema = z.object({
   timestamp: z.string().datetime(),
   stepCode: z.string(),
   question: z.string().optional(),
@@ -9,13 +11,39 @@ export const interactionLogSchema = z.object({
   agentResponse: z.string(),
   score: z.number().min(0).max(1).optional(),
   classification: z.string().optional(),
-  action: z.union([
-    z.literal('advance'),
-    z.literal('retry'),
-    z.literal('clarify'),
-    z.literal('complete')
-  ])
+  nextAction: nextActionSchema.optional(),
+  nextQuestion: z.string().optional(),
+  momentCompleted: z.boolean().optional(),
+  lessonCompleted: z.boolean().optional(),
+  needsAutomaticAdvance: z.boolean().optional(),
+  progressSummary: z.string().optional(),
+  weakAreas: z
+    .preprocess(value => {
+      if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (!trimmed) {
+          return [];
+        }
+        return trimmed.split(/[,\n]/).map(item => item.trim()).filter(Boolean);
+      }
+      if (Array.isArray(value)) {
+        return value;
+      }
+      if (value === undefined || value === null) {
+        return undefined;
+      }
+      return value;
+    }, z.array(z.string()).optional()),
+  riskMatrix: z.array(riskMatrixResultSchema).optional()
 });
+
+export const interactionLogSchema = z.preprocess(value => {
+  if (value && typeof value === 'object' && !Array.isArray(value) && 'action' in (value as Record<string, unknown>) && !(value as Record<string, unknown>).nextAction) {
+    const { action, ...rest } = value as Record<string, unknown> & { action?: unknown };
+    return { ...rest, nextAction: action };
+  }
+  return value;
+}, interactionLogBaseSchema);
 
 export const lessonSessionSchema = z.object({
   sessionId: z.string(),

--- a/src/services/openai-gateway.ts
+++ b/src/services/openai-gateway.ts
@@ -4,6 +4,7 @@ import type { Lesson, Moment, Step } from '../domain/lesson.js';
 import { lessonPlanSchema } from '../domain/lesson-plan.js';
 import { sophiaResponseSchema } from '../domain/responses.js';
 import type { SophiaResponse } from '../domain/responses.js';
+import { riskMatrixResultSchema } from '../domain/risk-matrix.js';
 import { messageTypeSchema } from '../domain/agent-messages.js';
 
 const conversationEntrySchema = z.object({
@@ -12,8 +13,12 @@ const conversationEntrySchema = z.object({
   stepCode: z.string(),
   score: z.number().min(0).max(1).optional(),
   classification: z.string().optional(),
-  action: z.string().optional(),
-  timestamp: z.string().optional()
+  nextAction: z.string().optional(),
+  timestamp: z.string().optional(),
+  nextQuestion: z.string().optional(),
+  progressSummary: z.string().optional(),
+  weakAreas: z.array(z.string()).optional(),
+  riskMatrix: z.array(riskMatrixResultSchema).optional()
 });
 
 const evaluateStepRequestSchema = z.object({
@@ -101,8 +106,12 @@ export class OpenAIGateway {
       stepCode: entry.stepCode,
       score: entry.score,
       classification: entry.classification,
-      action: entry.action,
-      timestamp: entry.timestamp
+      nextAction: entry.nextAction,
+      timestamp: entry.timestamp,
+      nextQuestion: entry.nextQuestion,
+      progressSummary: entry.progressSummary,
+      weakAreas: entry.weakAreas,
+      riskMatrix: entry.riskMatrix
     }));
 
     const userPrompt = [
@@ -126,8 +135,8 @@ export class OpenAIGateway {
       '- score: number entre 0 y 1.',
       '- nextAction: "advance"|"retry"|"clarify"|"complete".',
       '- nextQuestion (opcional).',
-      '- momentCompleted, lessonCompleted, needsAutomaticAdvance (opcional).',
-      '- progressSummary, weakAreas (opcional).',
+      '- momentCompleted, lessonCompleted, needsAutomaticAdvance (opcionales).',
+      '- progressSummary, weakAreas, riskMatrix (opcionales).',
       '',
       'No incluyas texto fuera del JSON.'
     ].join('\n');
@@ -185,8 +194,12 @@ export class OpenAIGateway {
         stepCode: entry.stepCode,
         score: entry.score,
         classification: entry.classification,
-        action: entry.action,
-        timestamp: entry.timestamp
+        nextAction: entry.nextAction,
+        timestamp: entry.timestamp,
+        nextQuestion: entry.nextQuestion,
+        progressSummary: entry.progressSummary,
+        weakAreas: entry.weakAreas,
+        riskMatrix: entry.riskMatrix
       }))
     };
 

--- a/src/services/sophia-multiagent-service.ts
+++ b/src/services/sophia-multiagent-service.ts
@@ -26,7 +26,21 @@ interface PersonalitySnapshot {
   attempts: number;
   historyLength: number;
   lastClassification?: SophiaResponse['classification'];
-  lastAction?: SophiaResponse['nextAction'];
+  lastNextAction?: SophiaResponse['nextAction'];
+}
+
+interface ModelHistoryItem {
+  role: 'user' | 'assistant';
+  message: string;
+  stepCode: string;
+  score?: number;
+  classification?: string;
+  nextAction?: string;
+  timestamp: string;
+  nextQuestion?: string;
+  progressSummary?: string;
+  weakAreas?: string[];
+  riskMatrix?: SophiaResponse['riskMatrix'];
 }
 
 export class SophiaMultiAgentService {
@@ -61,7 +75,7 @@ export class SophiaMultiAgentService {
       question: step.question,
       answerType: step.answerType,
       lastClassification: snapshot.lastClassification,
-      lastAction: snapshot.lastAction
+      lastAction: snapshot.lastNextAction
     };
 
     const baseInstructions = SophiaPersonality.buildInstructions(personalityContext);
@@ -69,6 +83,14 @@ export class SophiaMultiAgentService {
     const roleInstructions = EducationalRoles.getInstructions(roleDecision.role, personalityContext);
     const evaluationGuidelines = buildEvaluationGuidelines(step.objective, snapshot.attempts);
 
+    /**
+     * Formato esperado por el evaluador automatico.
+     * Campos requeridos: chat, classification, score, nextAction.
+     * Campos opcionales: nextQuestion, momentCompleted, lessonCompleted, needsAutomaticAdvance,
+     * progressSummary, weakAreas, riskMatrix.
+     * El historial enviado al modelo utiliza InteractionLog (ver src/domain/session.ts) y mantiene los
+     * nombres exactos: classification, nextAction, history[].
+     */
     const finalInstructions = [
       baseInstructions,
       '',
@@ -82,7 +104,8 @@ export class SophiaMultiAgentService {
       '',
       'FORMATO_DE_RESPUESTA',
       'Entrega JSON valido con las claves requeridas: chat, classification, score, nextAction.',
-      'Incluye nextQuestion si planteas la siguiente pregunta y marca momentCompleted/lessonCompleted cuando aplique.'
+      'Campos opcionales segun aplique: nextQuestion, momentCompleted, lessonCompleted, needsAutomaticAdvance, progressSummary, weakAreas, riskMatrix.',
+      'Asegurate de que history siga el formato de InteractionLog y registra riskMatrix solo cuando proveas un RiskMatrixResult.'
     ].join('\n');
 
     const historyForModel = this.buildHistoryForModel(safeSession.history);
@@ -128,20 +151,12 @@ export class SophiaMultiAgentService {
       attempts: historyForStep.length + 1,
       historyLength: session.history.length,
       lastClassification: lastEntry?.classification as SophiaResponse['classification'] | undefined,
-      lastAction: lastEntry?.action as SophiaResponse['nextAction'] | undefined
+      lastNextAction: lastEntry?.nextAction as SophiaResponse['nextAction'] | undefined
     };
   }
 
-  private buildHistoryForModel(history: InteractionLog[]) {
-    const items: Array<{
-      role: 'user' | 'assistant';
-      message: string;
-      stepCode: string;
-      score?: number;
-      classification?: string;
-      action?: string;
-      timestamp: string;
-    }> = [];
+  private buildHistoryForModel(history: InteractionLog[]): ModelHistoryItem[] {
+    const items: ModelHistoryItem[] = [];
 
     for (const entry of history) {
       if (entry.userInput === '[automatic]') {
@@ -154,8 +169,11 @@ export class SophiaMultiAgentService {
         stepCode: entry.stepCode,
         score: entry.score,
         classification: entry.classification,
-        action: entry.action,
-        timestamp: entry.timestamp
+        nextAction: entry.nextAction,
+        timestamp: entry.timestamp,
+        progressSummary: entry.progressSummary,
+        weakAreas: entry.weakAreas,
+        riskMatrix: entry.riskMatrix
       });
 
       if (entry.agentResponse) {
@@ -165,8 +183,12 @@ export class SophiaMultiAgentService {
           stepCode: entry.stepCode,
           score: entry.score,
           classification: entry.classification,
-          action: entry.action,
-          timestamp: entry.timestamp
+          nextAction: entry.nextAction,
+          timestamp: entry.timestamp,
+          nextQuestion: entry.nextQuestion,
+          progressSummary: entry.progressSummary,
+          weakAreas: entry.weakAreas,
+          riskMatrix: entry.riskMatrix
         });
       }
     }
@@ -334,7 +356,14 @@ function applyResponseToSession(
     agentResponse: response.chat,
     score: response.score,
     classification: response.classification,
-    action: response.nextAction
+    nextAction: response.nextAction,
+    nextQuestion: response.nextQuestion,
+    momentCompleted: response.momentCompleted,
+    lessonCompleted: response.lessonCompleted,
+    needsAutomaticAdvance: response.needsAutomaticAdvance,
+    progressSummary: response.progressSummary,
+    weakAreas: response.weakAreas,
+    riskMatrix: response.riskMatrix
   };
 
   const history = [...session.history, interaction];


### PR DESCRIPTION
## Summary
- add a RiskMatrixResult domain schema and expose it through SophiaResponse and interaction logs
- rename and enrich history entries with nextAction and optional metadata so the multi-agent service and gateway share a consistent contract
- document the expected JSON fields in SophiaMultiAgentService and update gateway prompts to mention every optional field explicitly

## Testing
- `npm run build` *(fails: TS2688 cannot find type definition file for 'node' in the repository image)*

------
https://chatgpt.com/codex/tasks/task_b_68d8a98252f4832c83d99b5800c38f3c