### PR TITLE
Fix snapshot history filter type annotation

### DIFF
--- a/src/services/sophia-multiagent-service.ts
+++ b/src/services/sophia-multiagent-service.ts
@@ -141,7 +141,7 @@ export class SophiaMultiAgentService {
   }
 
   private buildSnapshot(session: LessonSession, moment: Moment, step: AskStep): PersonalitySnapshot {
-    const historyForStep = session.history.filter(entry => entry.stepCode === step.code);
+    const historyForStep = session.history.filter((entry: InteractionLog) => entry.stepCode === step.code);
     const lastEntry = session.history.at(-1);
 
     return {


### PR DESCRIPTION
## Summary
- annotate the session history filter callback with the InteractionLog type to satisfy strict TypeScript checking

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d8b8363134832ca9a90795c9de7eed