### PR TITLE
Add model answer for IPERC greeting step

### DIFF
--- a/dist/data/lesson01.js
+++ b/dist/data/lesson01.js
@@ -31,6 +31,7 @@ export const lesson01 = {
                     type: 'ASK',
                     question: 'Si se lo explicas a un colega nuevo, como describirias un peligro y por que vale la pena detectarlo a tiempo?',
                     objective: 'Explorar por que conviene identificar peligros con anticipacion y reflexionar sobre su importancia en el dia a dia.',
+                    modelAnswer: 'Un peligro es cualquier condicion, objeto o accion que tiene el potencial real de causarnos dano; por ejemplo, un cable pelado que deja expuestos los conductores. Si alguien lo toca podria sufrir una descarga electrica seria o quemaduras, y al detectarlo a tiempo podemos aislarlo, avisar al equipo y evitar que el accidente o una lesion llegue a ocurrir.',
                     answerType: 'open',
                     image: {
                         url: 'https://www.levelset.com/wp-content/uploads/2019/02/bigstock-201485356-600x400.jpg',

--- a/dist/domain/lesson.js
+++ b/dist/domain/lesson.js
@@ -33,6 +33,7 @@ export const askStepSchema = baseStepSchema.extend({
         z.literal('list'),
         z.literal('procedure')
     ]),
+    modelAnswer: z.string().min(1).optional(),
     image: imageSchema.optional()
 });
 export const contentStepSchema = baseStepSchema.extend({

--- a/docs/iperc-continuo-flujo.md
+++ b/docs/iperc-continuo-flujo.md
@@ -1,0 +1,9 @@
+# Flujo conversacional de IPERC continuo
+
+## Momento M1 - Saludo / Paso M1-Q01
+- **Momento:** `M1` corresponde al saludo inicial de la leccion.
+- **Paso:** `M1-Q01` es la primera pregunta abierta y se encuentra en `src/data/lesson01.ts` dentro del arreglo `moments[0].steps[1]`.
+- **Propósito:** Invita a la persona en entrenamiento a explicar que es un peligro y por que detectarlo a tiempo es clave en el trabajo cotidiano.
+- **Respuesta modelo actualizada:** Refuerza la definicion de peligro, aporta un ejemplo concreto y explica la consecuencia potencial junto con el beneficio de anticipar el riesgo.
+
+Este mapa sirve como referencia rapida para ubicar el segmento al revisar o ajustar evaluaciones del flujo conversacional.

--- a/src/data/lesson01.ts
+++ b/src/data/lesson01.ts
@@ -33,6 +33,8 @@ export const lesson01: Lesson = {
           type: 'ASK',
           question: 'Si se lo explicas a un colega nuevo, como describirias un peligro y por que vale la pena detectarlo a tiempo?',
           objective: 'Explorar por que conviene identificar peligros con anticipacion y reflexionar sobre su importancia en el dia a dia.',
+          modelAnswer:
+            'Un peligro es cualquier condicion, objeto o accion que tiene el potencial real de causarnos dano; por ejemplo, un cable pelado que deja expuestos los conductores. Si alguien lo toca podria sufrir una descarga electrica seria o quemaduras, y al detectarlo a tiempo podemos aislarlo, avisar al equipo y evitar que el accidente o una lesion llegue a ocurrir.',
           answerType: 'open',
           image: {
             url: 'https://www.levelset.com/wp-content/uploads/2019/02/bigstock-201485356-600x400.jpg',

--- a/src/domain/lesson.ts
+++ b/src/domain/lesson.ts
@@ -43,6 +43,7 @@ export const askStepSchema = baseStepSchema.extend({
     z.literal('list'),
     z.literal('procedure')
   ]),
+  modelAnswer: z.string().min(1).optional(),
   image: imageSchema.optional()
 });
 


### PR DESCRIPTION
## Summary
- document the location of Momento M1 - Saludo / Paso M1-Q01 in the IPERC continuo flow
- extend ask step schema to allow optional model answers and expose the change in compiled assets
- add a formative model response for step M1-Q01 that includes definition, example, and consequence context

## Testing
- npm run build *(fails: missing local Node.js type dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d8b85a9a98832cbb46b78adbbb8248